### PR TITLE
Pont 3 api key to constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
  - Update open parameters schemas to follow current xcube conventions
  - Exclude ERA5 "monthly averages by hour of day" datasets
  - Add a Travis CI configuration for automated testing
+ - Add the ability to specify the CDS API URL and key as parameters to the
+   data store and data opener constructors
 
 ## Changes in 0.5.1
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ key: <UID>:<API-KEY>
 Replace `<UID>` with your UID and `<API-KEY>` with your API key, as obtained
 from the CDS website.
 
+You can specify an alternative location for the CDS API configuration file
+using the `CDSAPI_RC` environment variable, or provide the URL and key
+without a configuration file by setting the `CDSAPI_URL` and `CDSAPI_KEY`
+environment variables. You can also pass the URL and key directly to the
+`CDSDataOpener` and `CDSDataStore` constructors using the named parameters
+`cds_api_url` and `cds_api_key`.
+ 
 #### Agree to the terms of use for the datasets you require
 
 The datasets available through CDS have associated terms of use. Before

--- a/test/mocks.py
+++ b/test/mocks.py
@@ -11,13 +11,20 @@ class CDSClientMock:
     the retrieve method is called, it checks if the request matches one of
     these known requests, and if so returns the associated result (also read
     from disk). If the request cannot be matched, an exception is raised.
+
+    This class implements a minimal subset of the functionality of the
+    actual cdsapi.Client class, just sufficient to allow the unit tests to run.
     """
 
-    def __init__(self):
+    def __init__(self, url=None, key=None):
         class Session:
             def close(self):
                 pass
         self.session = Session()
+
+        self.url = url
+        self.key = key
+
         resource_path = os.path.join(os.path.dirname(__file__),
                                      'mock_results')
         # request_map is a list because dicts can't be hashed in Python, and

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -55,11 +55,15 @@ from xcube_cds.store import CDSDataOpener
 from xcube_cds.store import CDSDataStore
 from xcube_cds.store import CDSDatasetHandler
 
+_CDS_API_URL = 'dummy'
+_CDS_API_KEY = 'dummy'
 
 class CDSStoreTest(unittest.TestCase):
 
     def test_open(self):
-        opener = CDSDataOpener(client_class=CDSClientMock)
+        opener = CDSDataOpener(client_class=CDSClientMock,
+                               cds_api_url=_CDS_API_URL,
+                               cds_api_key=_CDS_API_KEY)
         dataset = opener.open_data(
             'reanalysis-era5-single-levels-monthly-means:'
             'monthly_averaged_reanalysis',
@@ -76,7 +80,9 @@ class CDSStoreTest(unittest.TestCase):
         self.assertEqual(10, len(dataset.variables['time']))
 
     def test_normalize_variable_names(self):
-        store = CDSDataStore(client_class=CDSClientMock, normalize_names=True)
+        store = CDSDataStore(client_class=CDSClientMock, normalize_names=True,
+                             cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         dataset = store.open_data(
             'reanalysis-era5-single-levels-monthly-means:'
             'monthly_averaged_reanalysis',
@@ -90,7 +96,8 @@ class CDSStoreTest(unittest.TestCase):
         self.assertTrue('p54_162' in dataset.variables)
 
     def test_invalid_data_id(self):
-        store = CDSDataStore()
+        store = CDSDataStore(cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         with self.assertRaises(ValueError):
             store.open_data(
                 'this-data-id-does-not-exist',
@@ -99,7 +106,8 @@ class CDSStoreTest(unittest.TestCase):
             )
 
     def test_request_parameter_out_of_range(self):
-        store = CDSDataStore()
+        store = CDSDataStore(cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         with self.assertRaises(ValidationError):
             store.open_data(
                 'reanalysis-era5-single-levels:ensemble_mean',
@@ -111,7 +119,9 @@ class CDSStoreTest(unittest.TestCase):
             )
 
     def test_era5_land_monthly(self):
-        store = CDSDataStore(client_class=CDSClientMock)
+        store = CDSDataStore(client_class=CDSClientMock,
+                             cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         dataset = store.open_data(
             'reanalysis-era5-land-monthly-means:'
             'monthly_averaged_reanalysis',
@@ -126,7 +136,9 @@ class CDSStoreTest(unittest.TestCase):
         self.assertTrue('u10' in dataset.variables)
 
     def test_era5_single_levels_hourly(self):
-        store = CDSDataStore(client_class=CDSClientMock)
+        store = CDSDataStore(client_class=CDSClientMock,
+                             cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         dataset = store.open_data(
             'reanalysis-era5-single-levels:'
             'reanalysis',
@@ -142,7 +154,9 @@ class CDSStoreTest(unittest.TestCase):
         self.assertEqual(26, len(dataset.variables['time']))
 
     def test_era5_land_hourly(self):
-        store = CDSDataStore(client_class=CDSClientMock)
+        store = CDSDataStore(client_class=CDSClientMock,
+                             cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         dataset = store.open_data(
             'reanalysis-era5-land',
             variable_names=['2m_temperature'],
@@ -157,7 +171,9 @@ class CDSStoreTest(unittest.TestCase):
         self.assertEqual(26, len(dataset.variables['time']))
 
     def test_era5_bounds(self):
-        opener = CDSDataOpener(client_class=CDSClientMock)
+        opener = CDSDataOpener(client_class=CDSClientMock,
+                             cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         dataset = opener.open_data(
             'reanalysis-era5-single-levels-monthly-means:'
             'monthly_averaged_reanalysis',
@@ -179,7 +195,9 @@ class CDSStoreTest(unittest.TestCase):
         self.assertLessEqual(south, north)
 
     def test_soil_moisture(self):
-        store = CDSDataStore(client_class=CDSClientMock)
+        store = CDSDataStore(client_class=CDSClientMock,
+                             cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         data_id = 'satellite-soil-moisture:volumetric:monthly'
         dataset = store.open_data(
             data_id,
@@ -200,7 +218,8 @@ class CDSStoreTest(unittest.TestCase):
                          sorted(map(str, dataset.data_vars)))
 
     def test_list_and_describe_data_ids(self):
-        store = CDSDataStore()
+        store = CDSDataStore(cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         data_ids = store.get_data_ids()
         self.assertIsInstance(data_ids, Iterator)
         for data_id in data_ids:
@@ -212,7 +231,8 @@ class CDSStoreTest(unittest.TestCase):
             self.assertIsInstance(descriptor, DataDescriptor)
 
     def test_open_data_empty_variables_list_1(self):
-        store = CDSDataStore()
+        store = CDSDataStore(cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         dataset = store.open_data(
             'reanalysis-era5-land-monthly-means:monthly_averaged_reanalysis',
             variable_names=[],
@@ -226,7 +246,8 @@ class CDSStoreTest(unittest.TestCase):
         self.assertEqual(361, len(dataset.variables['lon']))
 
     def test_open_data_empty_variables_list_2(self):
-        store = CDSDataStore()
+        store = CDSDataStore(cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         dataset = store.open_data(
             'satellite-soil-moisture:volumetric:10-day',
             variable_names=[],
@@ -241,7 +262,9 @@ class CDSStoreTest(unittest.TestCase):
         self.assertEqual(1441, len(dataset.variables['lon']))
 
     def test_open_data_null_variables_list(self):
-        store = CDSDataStore(client_class=CDSClientMock)
+        store = CDSDataStore(client_class=CDSClientMock,
+                             cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         data_id = 'reanalysis-era5-single-levels-monthly-means:'\
             'monthly_averaged_reanalysis'
         schema = store.get_open_data_params_schema(data_id)
@@ -257,7 +280,8 @@ class CDSStoreTest(unittest.TestCase):
         self.assertEqual(n_vars, len(dataset.data_vars))
 
     def test_era5_describe_data(self):
-        store = CDSDataStore()
+        store = CDSDataStore(cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         descriptor = store.describe_data(
             'reanalysis-era5-single-levels:reanalysis')
         self.assertEqual(265, len(descriptor.data_vars))
@@ -283,7 +307,8 @@ class CDSStoreTest(unittest.TestCase):
             CDSDatasetHandler.convert_time_range([])  # incorrect list length
 
     def test_get_open_params_schema_without_data_id(self):
-        opener = CDSDataOpener()
+        opener = CDSDataOpener(cds_api_url=_CDS_API_URL,
+                               cds_api_key=_CDS_API_KEY)
         schema = opener.get_open_data_params_schema()
 
         actual = schema.to_dict()
@@ -299,19 +324,23 @@ class CDSStoreTest(unittest.TestCase):
         )
 
     def test_search_data_invalid_id(self):
-        store = CDSDataStore()
+        store = CDSDataStore(cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         with self.assertRaises(DataStoreError):
             store.search_data('This is an invalid ID.')
 
     def test_search_data_valid_id(self):
-        store = CDSDataStore()
+        store = CDSDataStore(cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         # The CDS API doesn't offer a search function, so "not implemented"
         # is expected here.
         with self.assertRaises(NotImplementedError):
             store.search_data('dataset')
 
     def test_copy_on_open(self):
-        store = CDSDataStore(client_class=CDSClientMock)
+        store = CDSDataStore(client_class=CDSClientMock,
+                             cds_api_url=_CDS_API_URL,
+                             cds_api_key=_CDS_API_KEY)
         data_id = 'satellite-soil-moisture:volumetric:monthly'
         with tempfile.TemporaryDirectory() as temp_dir:
             request_path = os.path.join(temp_dir, 'request.json')

--- a/xcube_cds/store.py
+++ b/xcube_cds/store.py
@@ -299,8 +299,22 @@ class CDSDatasetHandler(ABC):
 class CDSDataOpener(DataOpener):
     """A data opener for the Copernicus Climate Data Store"""
 
-    def __init__(self, normalize_names: Optional[bool] = False,
-                 client=None):
+    def __init__(self,
+                 normalize_names: Optional[bool] = False,
+                 client_class=cdsapi.Client,
+                 cds_api_url=None,
+                 cds_api_key=None
+                 ):
+        """Instantiate a CDS data opener.
+
+        :param normalize_names: if True, all variable names in the returned
+               data set will comply with CF Conventions; any non-compliant
+               names in dataset returned by the CDS API will be changed.
+        :param client_class: cdsapi.Client (the class, not an instance), or
+               another class implementing the same interface. In practice, this
+               is expected to be either cdsapi.Client itself or a mock class for
+               testing.
+        """
         self._normalize_names = normalize_names
         self._create_temporary_directory()
         self._handler_registry: Dict[str, CDSDatasetHandler] = {}
@@ -309,7 +323,10 @@ class CDSDataOpener(DataOpener):
         from xcube_cds.datasets.satellite_soil_moisture \
             import SoilMoistureHandler
         self._register_dataset_handler(SoilMoistureHandler())
-        self._client = client or cdsapi.Client
+        self._client_class = client_class
+        self.cds_api_url = cds_api_url
+        self.cds_api_key = cds_api_key
+        self.last_instantiated_client = None  # for debugging and testing
 
     def _register_dataset_handler(self, handler: CDSDatasetHandler):
         for data_id in handler.get_supported_data_ids():
@@ -529,7 +546,12 @@ class CDSDataOpener(DataOpener):
         try:
             # The client class is set in the constructor. Usually it will
             # be cdsapi.Client, but may be mocked for unit testing.
-            client = self._client()
+            args = {}
+            if self.cds_api_url:
+                args['url'] = self.cds_api_url
+            if self.cds_api_key:
+                args['key'] = self.cds_api_key
+            self.last_instantiated_client = client = self._client_class(**args)
 
             # We can't generate a safe unique filename (since the file is
             # created by client.retrieve, so name generation and file

--- a/xcube_cds/store.py
+++ b/xcube_cds/store.py
@@ -314,6 +314,12 @@ class CDSDataOpener(DataOpener):
                another class implementing the same interface. In practice, this
                is expected to be either cdsapi.Client itself or a mock class for
                testing.
+        :param cds_api_url: CDS API URL. Will be passed to the CDS API client.
+               If omitted, the client will read the value from an environment
+               variable or configuration file.
+        :param cds_api_url: CDS API key. Will be passed to the CDS API client.
+               If omitted, the client will read the value from an environment
+               variable or configuration file.
         """
         self._normalize_names = normalize_names
         self._create_temporary_directory()


### PR DESCRIPTION
This PR adds `cds_api_url` and `cds_api_key` parameters to the `CDSDataOpener` and `CDSDataStore` constructors. Previously, the CDS API URl and key could only be specified via environment variables or a configuration file.