### PR TITLE
AppVeyor config: add micromamba, install xcube from repo

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,36 +34,20 @@ build_script:
   - export MAMBA_EXE=$(pwd)/micromamba
   - . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
 
-  # Install the packages required by xcube-cds (including xcube and its
-  # dependencies)
-  - micromamba create --yes --name xcube --file environment.yml
-  - micromamba activate xcube
-  - micromamba install -vvv --yes --name xcube --channel conda-forge attrs
-
-  # Clone the xcube repository and install its dependencies using its conda
-  # environment file
   - git clone https://github.com/dcs4cop/xcube $HOME/xcube
-  - micromamba update --name xcube --file $HOME/xcube/environment.yml
-
-  # Remove the xcube conda package itself, because we want to install xcube
-  # directly from its repository instead.
-  - micromamba remove --name xcube xcube
-
-  # List the installed packages (useful for debugging).
-  - micromamba list
-  - micromamba list --name xcube
-
-  # Install xcube from its repository using setuptools.
+  - micromamba create --name xc --file $HOME/xcube/environment.yml
+  - micromamba activate xc
   - cd $HOME/xcube
   - python setup.py install
 
-  # Install xcube-cds from its repository using setuptools.
   - cd $APPVEYOR_BUILD_FOLDER
+  - grep -v "^  - xcube" environment.yml > env_no_xcube.yml
+  - micromamba update --yes --name xc --file env_no_xcube.yml
   - python setup.py install
 
   # Run the test suite.
-  - micromamba activate xcube
-  - micromamba install --yes --name xcube --channel conda-forge pytest attrs
+  - micromamba activate xc
+  - micromamba install --yes --name xc --channel conda-forge pytest attrs
   - python -c "import sys; print(sys.path)"
-  - ls -1 $HOME/micromamba/envs/xcube/lib/python3.9/site-packages/
+  - ls -1 $HOME/micromamba/envs/xc/lib/python3.9/site-packages/
   - python -m pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,4 +61,4 @@ build_script:
   - python setup.py install
 
   # Run the test suite.
-  - py.test
+  - python -m pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: '{build}'
 
 image:
-  - macos
   - Ubuntu2004
+  - macos
 
 configuration: Release
 
@@ -25,6 +25,7 @@ for:
     - wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
 
 build_script:
+  # Set up micromamba
   - ./micromamba shell init -s bash -p ~/micromamba
   - source ~/.bashrc
   - source ~/.bash_profile
@@ -34,20 +35,21 @@ build_script:
   - export MAMBA_EXE=$(pwd)/micromamba
   - . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
 
+  # Clone xcube repository, install xcube dependencies with micromamba,
+  # and install the latest version of xcube with setup.py.
   - git clone https://github.com/dcs4cop/xcube $HOME/xcube
   - micromamba create --name xc --file $HOME/xcube/environment.yml
   - micromamba activate xc
   - cd $HOME/xcube
   - python setup.py install
 
+  # Use micromamba to install all xcube-cds dependencies *except* xcube
+  # (already manually installed), then install xcube-cds itself with setup.py.
   - cd $APPVEYOR_BUILD_FOLDER
   - grep -v "^  - xcube" environment.yml > env_no_xcube.yml
   - micromamba update --yes --name xc --file env_no_xcube.yml
   - python setup.py install
 
-  # Run the test suite.
-  - micromamba activate xc
+  # Make sure pytest is installed and run the test suite.
   - micromamba install --yes --name xc --channel conda-forge pytest attrs
-  - python -c "import sys; print(sys.path)"
-  - ls -1 $HOME/micromamba/envs/xc/lib/python3.9/site-packages/
   - python -m pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ build_script:
   # dependencies), as well as the pytest package (needed for testing).
   - micromamba create --yes --name xcube --file environment.yml
   - micromamba activate xcube
-  - micromamba install --yes --name xcube --channel conda-forge pytest
+  - micromamba install --yes --name xcube --channel conda-forge pytest attr
 
   # Clone the xcube repository and install its dependencies using its conda
   # environment file

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,4 +61,7 @@ build_script:
 
   # Run the test suite.
   - micromamba install --yes --name xcube --channel conda-forge pytest attrs
+  - micromamba activate xcube
+  - python -c "import sys; print(sys.path)"
+  - ls $HOME/micromamba/envs/xcube/lib/python3.9/site-packages/
   - python -m pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,4 +61,4 @@ build_script:
   - python setup.py install
 
   # Run the test suite.
-  - pytest
+  - py.test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,10 +35,9 @@ build_script:
   - . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
 
   # Install the packages required by xcube-cds (including xcube and its
-  # dependencies), as well as the pytest package (needed for testing).
+  # dependencies)
   - micromamba create --yes --name xcube --file environment.yml
   - micromamba activate xcube
-  - micromamba install --yes --name xcube --channel conda-forge pytest attr
 
   # Clone the xcube repository and install its dependencies using its conda
   # environment file
@@ -61,4 +60,5 @@ build_script:
   - python setup.py install
 
   # Run the test suite.
+  - micromamba install --yes --name xcube --channel conda-forge pytest attrs
   - python -m pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ build_script:
   # dependencies)
   - micromamba create --yes --name xcube --file environment.yml
   - micromamba activate xcube
+  - micromamba install -vvv --yes --name xcube --channel conda-forge attrs
 
   # Clone the xcube repository and install its dependencies using its conda
   # environment file
@@ -60,8 +61,8 @@ build_script:
   - python setup.py install
 
   # Run the test suite.
-  - micromamba install --yes --name xcube --channel conda-forge pytest attrs
   - micromamba activate xcube
+  - micromamba install --yes --name xcube --channel conda-forge pytest attrs
   - python -c "import sys; print(sys.path)"
-  - ls $HOME/micromamba/envs/xcube/lib/python3.9/site-packages/
+  - ls -1 $HOME/micromamba/envs/xcube/lib/python3.9/site-packages/
   - python -m pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,18 +36,18 @@ build_script:
 
   # Install the packages required by xcube-cds (including xcube and its
   # dependencies), as well as the pytest package (needed for testing).
-  - micromamba create --yes --file environment.yml
+  - micromamba create --yes --name xcube --file environment.yml
   - micromamba activate xcube-cds
-  - micromamba install --channel conda-forge pytest
+  - micromamba install --yes --name xcube --channel conda-forge pytest
 
   # Clone the xcube repository and install its dependencies using its conda
   # environment file
   - git clone https://github.com/dcs4cop/xcube $HOME/xcube
-  - micromamba update --file $HOME/xcube/environment.yml
+  - micromamba update --name xcube --file $HOME/xcube/environment.yml
 
   # Remove the xcube conda package itself, because we want to install xcube
   # directly from its repository instead.
-  - micromamba remove --prefix $HOME/mamba-env xcube
+  - micromamba remove --name xcube xcube
 
   # List the installed packages (useful for debugging).
   - micromamba list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,7 @@ build_script:
 
   # List the installed packages (useful for debugging).
   - micromamba list
+  - micromamba list --name xcube
 
   # Install xcube from its repository using setuptools.
   - cd $HOME/xcube

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ build_script:
   # Install the packages required by xcube-cds (including xcube and its
   # dependencies), as well as the pytest package (needed for testing).
   - micromamba create --yes --name xcube --file environment.yml
-  - micromamba activate xcube-cds
+  - micromamba activate xcube
   - micromamba install --yes --name xcube --channel conda-forge pytest
 
   # Clone the xcube repository and install its dependencies using its conda

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,13 @@ build_script:
   - micromamba update --yes --name xc --file env_no_xcube.yml
   - python setup.py install
 
-  # Make sure pytest is installed and run the test suite.
+  # Make sure pytest is installed
   - micromamba install --yes --name xc --channel conda-forge pytest attrs
+
+  # Print some diagnostics (useful for debugging)
+  - micromamba list
+  - xcube --version
+  - python -c "from xcube_cds.version import version; print(f'xcube_cds version {version}')"
+
+  # Run the test suite
   - python -m pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ build_script:
   # Install the packages required by xcube-cds (including xcube and its
   # dependencies), as well as the pytest package (needed for testing).
   - micromamba create --yes --file environment.yml
+  - micromamba activate xcube-cds
   - micromamba install --channel conda-forge pytest
 
   # Clone the xcube repository and install its dependencies using its conda

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,52 +15,41 @@ for:
     only:
       - image: macos
   install:
-    - curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
+    - curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+    - mv bin/micromamba ./micromamba
 -
   matrix:
     only:
       - image: Ubuntu2004
   install:
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
+    - wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
 
 build_script:
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - ./micromamba shell init -s bash -p ~/micromamba
+  - source ~/.bashrc
+  - source ~/.bash_profile
   - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  # - conda update -q conda # makes travis build fail
-  - conda info -a  # Useful for debugging any issues with conda
-  - conda init bash
-  - export CONDA_BASE=$(conda info --base)
-  - source $CONDA_BASE/etc/profile.d/conda.sh
-
-  # Install mamba as a dramatically faster conda replacement. Specifying a
-  # fixed version makes the installation of mamba itself much faster, and
-  # avoids potential breakage due to changes in mamba behaviour.
-  - conda install mamba=0.7.3 -c conda-forge
-
-  # Environments created by mamba can't be referenced by name from conda
-  # (presumably a bug), so we use an explicit path instead.
+  - mkdir -p ~/micromamba/pkgs/
+  - export MAMBA_ROOT_PREFIX=~/micromamba
+  - export MAMBA_EXE=$(pwd)/micromamba
+  - . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
 
   # Install the packages required by xcube-cds (including xcube and its
   # dependencies), as well as the pytest package (needed for testing).
-  - mamba env create --prefix $HOME/mamba-env --file environment.yml
-  - mamba install --prefix $HOME/mamba-env pytest
+  - micromamba create --yes --file environment.yml
+  - micromamba install --channel conda-forge pytest
 
   # Clone the xcube repository and install its dependencies using its conda
   # environment file
   - git clone https://github.com/dcs4cop/xcube $HOME/xcube
-  - mamba env update --prefix $HOME/mamba-env --file $HOME/xcube/environment.yml
+  - micromamba update --file $HOME/xcube/environment.yml
 
   # Remove the xcube conda package itself, because we want to install xcube
   # directly from its repository instead.
-  - mamba remove --prefix $HOME/mamba-env xcube
+  - micromamba remove --prefix $HOME/mamba-env xcube
 
-  # Activate the conda environment and list the installed packages (useful for
-  # debugging).
-  - conda activate $HOME/mamba-env
-  - conda list
+  # List the installed packages (useful for debugging).
+  - micromamba list
 
   # Install xcube from its repository using setuptools.
   - cd $HOME/xcube
@@ -72,4 +61,3 @@ build_script:
 
   # Run the test suite.
   - pytest
-


### PR DESCRIPTION
Rewrite the AppVeyor config to use micromamba instead of installing mamba with conda, and to install xcube from its repository without trying to find a conda-forge release.

Closes #43.
Closes #50.
