### PR TITLE
Update appveyor.yml (mainly to fix CI on Ubuntu)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: '{build}'
 
 image:
+  - Ubuntu2204
   - macos
-  - Ubuntu2004
 
 configuration: Release
 
@@ -16,14 +16,15 @@ for:
       - image: macos
       - image: Previous macos  # not usually needed, but might use it while debugging
   install:
-    - curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+    - curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
     - mv bin/micromamba ./micromamba
 -
   matrix:
     only:
-      - image: Ubuntu2004
+      - image: Ubuntu2204
   install:
-    - wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
+    - curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+    - mv bin/micromamba ./micromamba
 
 build_script:
   # Diagnostics
@@ -36,7 +37,7 @@ build_script:
   # Set up micromamba
   - ./micromamba shell init -s bash -p ~/micromamba
   - source ~/.bashrc
-  - source ~/.bash_profile
+  - source ~/.profile
   - hash -r
   - mkdir -p ~/micromamba/pkgs/
   - export MAMBA_ROOT_PREFIX=~/micromamba


### PR DESCRIPTION
- When setting up environment, source ~/.profile rather than the now non-existent ~/.bash_profile (fixes #74).

- Update Ubuntu image from ubuntu2004 to ubuntu2204.

- Re-order image configurations to put Ubuntu first.

- Update micromamba download URLs to current official recommendations (old URLs still work, but we don't know for how long this will continue to be the case).