### PR TITLE
AppVeyor micromamba shell init -p -> --root-prefix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ build_script:
   - ls
 
   # Set up micromamba
-  - ./micromamba shell init -s bash -p ~/micromamba
+  - ./micromamba shell init -s bash --root-prefix ~/micromamba
   - source ~/.bashrc
   - source ~/.profile
   - hash -r


### PR DESCRIPTION
Use `--root-prefix`, not `-p`, to specify the root prefix in the `mamba shell init` invocation in the AppVeyor config, since the latter will be unsupported as of micromamba 2.0.

Closes #82.